### PR TITLE
avoid latest pykdtree version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ lapy>=1.0.0
 kaleido>=0.2.1
 scikit-image
 importlib_resources
+pykdtree!=1.3.13


### PR DESCRIPTION
Trying if a newer dependency causes the macOS build failures.